### PR TITLE
Fix compatibility with 1.21.9 pack.mcmeta format

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,52 +1,52 @@
 {
-  "pack": {
-    "_author": "MukiTanuki",
-    "_version": 2.1,
-    "pack_format": 18,
-    "supported_formats": {
-      "min_inclusive": 18,
-      "max_inclusive": 48
+    "pack": {
+        "_author": "MukiTanuki",
+        "_version": 2.1,
+        "pack_format": 18,
+        "supported_formats": {
+            "min_inclusive": 18,
+            "max_inclusive": 48
+        },
+        "description": "Name Formatting Station"
     },
-    "description": "Name Formatting Station"
-  },
-  "overlays": {
-    "entries": [
-      {
-        "directory": "1_20_3",
-        "min_format": 19,
-        "max_format": 9999999,
-        "formats": {
-          "min_inclusive": 19,
-          "max_inclusive": 9999999
-        }
-      },
-      {
-        "directory": "1_20_5",
-        "min_format": 41,
-        "max_format": 9999999,
-        "formats": {
-          "min_inclusive": 41,
-          "max_inclusive": 9999999
-        }
-      },
-      {
-        "directory": "1_21_0",
-        "min_format": 48,
-        "max_format": 9999999,
-        "formats": {
-          "min_inclusive": 48,
-          "max_inclusive": 9999999
-        }
-      },
-      {
-        "directory": "1_21_5",
-        "min_format": 71,
-        "max_format": 9999999,
-        "formats": {
-          "min_inclusive": 71,
-          "max_inclusive": 9999999
-        }
-      }
-    ]
-  }
+    "overlays": {
+        "entries": [
+            {
+                "directory": "1_20_3",
+                "min_format": 19,
+                "max_format": 9999999,
+                "formats": {
+                    "min_inclusive": 19,
+                    "max_inclusive": 9999999
+                }
+            },
+            {
+                "directory": "1_20_5",
+                "min_format": 41,
+                "max_format": 9999999,
+                "formats": {
+                    "min_inclusive": 41,
+                    "max_inclusive": 9999999
+                }
+            },
+            {
+                "directory": "1_21_0",
+                "min_format": 48,
+                "max_format": 9999999,
+                "formats": {
+                    "min_inclusive": 48,
+                    "max_inclusive": 9999999
+                }
+            },
+            {
+                "directory": "1_21_5",
+                "min_format": 71,
+                "max_format": 9999999,
+                "formats": {
+                    "min_inclusive": 71,
+                    "max_inclusive": 9999999
+                }
+            }
+        ]
+    }
 }

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,44 +1,52 @@
 {
-   "pack": {
-      "_author": "MukiTanuki",
-	   "_version": 2.1,
-      "pack_format": 18,
-		"supported_formats": {
-			"min_inclusive": 18,
-			"max_inclusive": 48
-		},
-      "description": "Name Formatting Station"
-   },
-	"overlays": {
-		"entries": [
-			{
-				"directory": "1_20_3",
-				"formats": {
-					"min_inclusive": 19,
-					"max_inclusive": 9999999
-				}
-			},
-			{
-				"directory": "1_20_5",
-				"formats": {
-					"min_inclusive": 41,
-					"max_inclusive": 9999999
-				}
-			},
-			{
-				"directory": "1_21_0",
-				"formats": {
-					"min_inclusive": 48,
-					"max_inclusive": 9999999
-				}
-			},
-			{
-				"directory": "1_21_5",
-				"formats": {
-					"min_inclusive": 71,
-					"max_inclusive": 9999999
-				}
-			}
-		]
-	}
+  "pack": {
+    "_author": "MukiTanuki",
+    "_version": 2.1,
+    "pack_format": 18,
+    "supported_formats": {
+      "min_inclusive": 18,
+      "max_inclusive": 48
+    },
+    "description": "Name Formatting Station"
+  },
+  "overlays": {
+    "entries": [
+      {
+        "directory": "1_20_3",
+        "min_format": 19,
+        "max_format": 9999999,
+        "formats": {
+          "min_inclusive": 19,
+          "max_inclusive": 9999999
+        }
+      },
+      {
+        "directory": "1_20_5",
+        "min_format": 41,
+        "max_format": 9999999,
+        "formats": {
+          "min_inclusive": 41,
+          "max_inclusive": 9999999
+        }
+      },
+      {
+        "directory": "1_21_0",
+        "min_format": 48,
+        "max_format": 9999999,
+        "formats": {
+          "min_inclusive": 48,
+          "max_inclusive": 9999999
+        }
+      },
+      {
+        "directory": "1_21_5",
+        "min_format": 71,
+        "max_format": 9999999,
+        "formats": {
+          "min_inclusive": 71,
+          "max_inclusive": 9999999
+        }
+      }
+    ]
+  }
 }

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,52 +1,52 @@
 {
-    "pack": {
-        "_author": "MukiTanuki",
-        "_version": 2.1,
-        "pack_format": 18,
-        "supported_formats": {
-            "min_inclusive": 18,
-            "max_inclusive": 48
-        },
-        "description": "Name Formatting Station"
-    },
-    "overlays": {
-        "entries": [
-            {
-                "directory": "1_20_3",
-                "min_format": 19,
-                "max_format": 9999999,
-                "formats": {
-                    "min_inclusive": 19,
-                    "max_inclusive": 9999999
-                }
-            },
-            {
-                "directory": "1_20_5",
-                "min_format": 41,
-                "max_format": 9999999,
-                "formats": {
-                    "min_inclusive": 41,
-                    "max_inclusive": 9999999
-                }
-            },
-            {
-                "directory": "1_21_0",
-                "min_format": 48,
-                "max_format": 9999999,
-                "formats": {
-                    "min_inclusive": 48,
-                    "max_inclusive": 9999999
-                }
-            },
-            {
-                "directory": "1_21_5",
-                "min_format": 71,
-                "max_format": 9999999,
-                "formats": {
-                    "min_inclusive": 71,
-                    "max_inclusive": 9999999
-                }
+   "pack": {
+      "_author": "MukiTanuki",
+      "_version": 2.1,
+      "pack_format": 18,
+      "supported_formats": {
+         "min_inclusive": 18,
+         "max_inclusive": 48
+      },
+      "description": "Name Formatting Station"
+   },
+   "overlays": {
+      "entries": [
+         {
+            "directory": "1_20_3",
+            "min_format": 19,
+            "max_format": 9999999,
+            "formats": {
+               "min_inclusive": 19,
+               "max_inclusive": 9999999
             }
-        ]
-    }
+         },
+         {
+            "directory": "1_20_5",
+            "min_format": 41,
+            "max_format": 9999999,
+            "formats": {
+               "min_inclusive": 41,
+               "max_inclusive": 9999999
+            }
+         },
+         {
+            "directory": "1_21_0",
+            "min_format": 48,
+            "max_format": 9999999,
+            "formats": {
+               "min_inclusive": 48,
+               "max_inclusive": 9999999
+            }
+         },
+         {
+            "directory": "1_21_5",
+            "min_format": 71,
+            "max_format": 9999999,
+            "formats": {
+               "min_inclusive": 71,
+               "max_inclusive": 9999999
+            }
+         }
+      ]
+   }
 }


### PR DESCRIPTION
Fixes error: "Overlay "1_20_3" declares support for version newer than 81, but is missing mandatory fields min_format and max_format"

Resolves #9 